### PR TITLE
Fix booking form endpoint mismatch

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -552,7 +552,7 @@
             };
             
             // Send booking to API
-            fetch('/api/bookings', {
+            fetch('/api/booking', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- correct booking API path in public script

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684005109828832e8c5b0a639f1fa5a1